### PR TITLE
Use a proper factory pattern for instantiating the ethereum client

### DIFF
--- a/ethereum.services.yml
+++ b/ethereum.services.yml
@@ -1,0 +1,7 @@
+services:
+  ethereum.client:
+    class: Ethereum\Ethereum
+    factory: ethereum.client_factory:get
+  ethereum.client_factory:
+    class: Drupal\ethereum\EthereumClientFactory
+    arguments: ['@config.factory']

--- a/ethereum_user_connector/src/Controller/EthereumUserConnectorController.php
+++ b/ethereum_user_connector/src/Controller/EthereumUserConnectorController.php
@@ -1,13 +1,7 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ethereum\Controller\EthereumController.
- */
-
 namespace Drupal\ethereum_user_connector\Controller;
 
-use Drupal;
 use Drupal\ethereum\Controller\EthereumController;
 use Ethereum\CallTransaction;
 use Ethereum\EthD;
@@ -15,7 +9,7 @@ use Ethereum\EthD20;
 use Ethereum\EthS;
 
 /**
- * Controller routines for Ethereum routes.
+ * Controller routines for Ethereum User Connector routes.
  */
 class EthereumUserConnectorController extends EthereumController {
 
@@ -26,8 +20,8 @@ class EthereumUserConnectorController extends EthereumController {
    *   Address of the currently active contract.
    */
   public static function getContractAddress() {
-    $current = Drupal::config('ethereum.settings')->get('current_server');
-    return Drupal::config('ethereum_user_connector.settings')->get($current);
+    $current = \Drupal::config('ethereum.settings')->get('current_server');
+    return \Drupal::config('ethereum_user_connector.settings')->get($current);
   }
 
   /**
@@ -79,7 +73,7 @@ class EthereumUserConnectorController extends EthereumController {
       }
 
       // Check if User Exists
-      $query = Drupal::service('entity.query')
+      $query = \Drupal::service('entity.query')
         ->get('user')
         ->condition('field_ethereum_drupal_hash', $hash)
         ->condition('field_ethereum_address', $user_address->hexVal());
@@ -91,7 +85,7 @@ class EthereumUserConnectorController extends EthereumController {
 
       // Update User's ethereum_account_status field.
       $uid = reset($entity_ids);
-      $user = Drupal::entityTypeManager()->getStorage('user')->load($uid);
+      $user = \Drupal::entityTypeManager()->getStorage('user')->load($uid);
       $user->field_ethereum_account_status->setValue('2');
       if ($user->save() !== SAVED_UPDATED) {
         throw new \Exception('Error updating user Ethereum status for UID: ' . $uid);

--- a/ethereum_user_connector/src/Form/AdminForm.php
+++ b/ethereum_user_connector/src/Form/AdminForm.php
@@ -1,25 +1,49 @@
 <?php
-/**
-* @file
-* Contains \Drupal\ethereum\Form\AdminForm.
-*/
 
 namespace Drupal\ethereum_user_connector\Form;
 
-use Drupal;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\ethereum_user_connector\Controller\EthereumUserConnectorController;
+use Drupal\Core\Url;
+use Ethereum\CallTransaction;
 use Ethereum\EthBlockParam;
 use Ethereum\EthD;
 use Ethereum\EthD20;
-use Drupal\Core\Url;
-use Ethereum\CallTransaction;
+use Ethereum\Ethereum;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
 * Defines a form to configure maintenance settings for this site.
 */
-class AdminForm extends ConfigFormBase {
+class AdminForm extends ConfigFormBase implements ContainerInjectionInterface {
+
+  /**
+   * The Ethereum JsonRPC client.
+   *
+   * @var \Ethereum\Ethereum
+   */
+  protected $client;
+
+  /**
+   * Constructs a new AdminForm.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, Ethereum $ethereum_client) {
+    parent::__construct($config_factory);
+
+    $this->client = $ethereum_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('ethereum.client')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -126,12 +150,10 @@ f845862f newUser(bytes32)
     $custom_val = trim($form_state->getValue('custom'));
     $form_state->setValue('custom', $custom_val);
 
-    $active_server = Drupal::config('ethereum.settings')->get('current_server');
+    $active_server = $this->configFactory->get('ethereum.settings')->get('current_server');
     $val = $form_state->getValue($active_server);
 
     try {
-      $eth = new EthereumUserConnectorController();
-
       // Validate contract address.
       $signature = '0x' . $this->config('ethereum_user_connector.settings')->get('contract_contractExists_call');
       /**
@@ -139,7 +161,7 @@ f845862f newUser(bytes32)
        * curl -X POST --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaaaafb8dbb9f5c9d82f085e770f4ed65f3b3107c", "data":"0x06ae9483"},"latest"],"id":1}' localhost:8545
       */
       $message = new CallTransaction(new EthD20($val), NULL, NULL, NULL, NULL, new EthD($signature));
-      $result = $eth->client->eth_call($message, new EthBlockParam());
+      $result = $this->client->eth_call($message, new EthBlockParam());
       //
       // Debug JsonRPC contract validation call.
       // $eth->debug();

--- a/src/Controller/EthereumController.php
+++ b/src/Controller/EthereumController.php
@@ -1,37 +1,44 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ethereum\Controller\EthereumController.
- */
-
 namespace Drupal\ethereum\Controller;
 
-//use Drupal;
-use Drupal\Console\Bootstrap\Drupal;
 use Drupal\Core\Controller\ControllerBase;
-use Ethereum\Ethereum;
 use Ethereum\EthBlockParam;
 use Ethereum\EthB;
+use Ethereum\Ethereum;
 use Ethereum\EthS;
 use Drupal\Core\Render\Markup;
 use Drupal\ethereum\Entity\EthereumServer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller routines for Ethereum routes.
  */
 class EthereumController extends ControllerBase {
 
-  private $config;
-  public $client;
+  /**
+   * The Ethereum JsonRPC client.
+   *
+   * @var \Ethereum\Ethereum
+   */
+  protected $client;
+
   private $debug = TRUE;
 
-  public function __construct($host = FALSE) {
-    if (!$host) {
-      $this->config = \Drupal::config('ethereum.settings');
-      $host = $this->config->get($this->config->get('current_server'));
-    }
-    $this->client = new Ethereum($host);
+  /**
+   * Constructs a new EthereumController.
+   */
+  public function __construct(Ethereum $ethereum_client) {
+    $this->client = $ethereum_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('ethereum.client')
+    );
   }
 
   /**
@@ -222,7 +229,7 @@ class EthereumController extends ControllerBase {
 
     // Testing_only.
 
-    $block_earliest = $this->client->eth_getBlockByNumber(new EthBlockParam(1), new EthB(FALSE));
+    $block_earliest = $this->client->eth_getBlockByNumber(new EthBlockParam('earliest'), new EthB(FALSE));
     $rows[] = [
       $this->t("Age of block number '1' <br/><small>The 'earliest' block has no timestamp on many networks.</small>"),
       \Drupal::service('date.formatter')->format($block_earliest->getProperty('timestamp'), 'html_datetime'),

--- a/src/EthereumClientFactory.php
+++ b/src/EthereumClientFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\ethereum;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\ethereum\Entity\EthereumServer;
+use Ethereum\Ethereum;
+
+/**
+ * Helper class to construct a Ethereum JsonRPC client.
+ */
+class EthereumClientFactory {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new EthereumClientFactory.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Constructs a new Ethereum client object from a host URL.
+   *
+   * @param string $host
+   *   (optional) The host URL for the client.
+   *
+   * @return \Ethereum\Ethereum
+   *   The Ethereum client.
+   */
+  public function get($host = NULL) {
+    if (!$host) {
+      $current_server = $this->configFactory->get('ethereum.settings')->get('current_server');
+      $host = EthereumServer::load($current_server)->get('url');
+    }
+
+    return new Ethereum($host);
+  }
+
+}


### PR DESCRIPTION
Currently, the ethereum client is instantiated in `EthereumController` and used in various places, but that's not really the purpose of controllers :)

Instead, we should have a service for getting the ethereum client, and a factory service for instantiating it.

This PR also cleans up a bit the files which were using the ethereum client, and makes the status report page work on my local ganache dev environment.