### PR TITLE
Store the Ethereum network in the Ethereum address field.

### DIFF
--- a/ethereum.module
+++ b/ethereum.module
@@ -52,6 +52,31 @@ function ethereum_field_formatter_info_alter(array &$info) {
 }
 
 /**
+ * Implements hook_field_views_data().
+ */
+function ethereum_field_views_data(\Drupal\field\FieldStorageConfigInterface $field_storage) {
+  $data = views_field_default_views_data($field_storage);
+  foreach ($data as $table_name => $table_data) {
+    // Add the relationship only on the target_id field.
+    $data[$table_name][$field_storage->getName() . '_network']['filter']['id'] = 'in_operator';
+    $data[$table_name][$field_storage->getName() . '_network']['filter']['options callback'] = '_ethereum_get_networks_options';
+  }
+
+  return $data;
+}
+
+/**
+ * Returns the Ethereum networks as an array suitable for an options element.
+ *
+ * @return array
+ *   An array of Ethereum Networks containing the network name, ID, and
+ *   description, keyed by the network ID.
+ */
+function _ethereum_get_networks_options() {
+  return \Drupal::service('ethereum.manager')->getNetworksAsOptions();
+}
+
+/**
  * Implements hook_js_settings_alter().
  *
  * @param $settings

--- a/src/Plugin/Field/FieldFormatter/EthereumAddressFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EthereumAddressFormatter.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Drupal\ethereum\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\Annotation\FieldFormatter;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\BasicStringFormatter;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\ethereum\Controller\EthereumController;
+use Drupal\ethereum\Plugin\Field\FieldType\EthereumAddressItem;
+
+/**
+ * Plugin implementation of the 'ethereum_address' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "ethereum_address",
+ *   label = @Translation("Ethereum address"),
+ *   field_types = {
+ *     "ethereum_address"
+ *   }
+ * )
+ */
+class EthereumAddressFormatter extends BasicStringFormatter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'link_to_network' => '',
+      'rel' => '',
+      'target' => '',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements = parent::settingsForm($form, $form_state);
+
+    $elements['link_to_network'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Link to the network address page'),
+      '#default_value' => $this->getSetting('link_to_network'),
+    ];
+    $elements['rel'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Add rel="nofollow" to the link'),
+      '#return_value' => 'nofollow',
+      '#default_value' => $this->getSetting('rel'),
+      '#states' => array(
+        'visible' => array(
+          array(
+            'input[name="fields[' . $this->fieldDefinition->getName() . '][settings_edit_form][settings][link_to_network]"]' => array('checked' => TRUE),
+          ),
+        ),
+      ),
+    ];
+    $elements['target'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Open link in new window'),
+      '#return_value' => '_blank',
+      '#default_value' => $this->getSetting('target'),
+      '#states' => array(
+        'visible' => array(
+          array(
+            'input[name="fields[' . $this->fieldDefinition->getName() . '][settings_edit_form][settings][link_to_network]"]' => array('checked' => TRUE),
+          ),
+        ),
+      ),
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $settings = $this->getSettings();
+
+    if (!empty($settings['link_to_network'])) {
+      $summary[] = $this->t('Link to the network address page');
+    }
+    if (!empty($settings['rel'])) {
+      $summary[] = $this->t('Add rel="@rel"', ['@rel' => $settings['rel']]);
+    }
+    if (!empty($settings['target'])) {
+      $summary[] = $this->t('Open link in new window');
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    $settings = $this->getSettings();
+
+    if (empty($settings['link_to_network'])) {
+      return parent::viewElements($items, $langcode);
+    }
+
+    $networks = EthereumController::getNetworks();
+    foreach ($items as $delta => $item) {
+      $url = $this->buildUrl($item, $networks[$item->network]);
+
+      $elements[$delta] = [
+        '#type' => 'link',
+        '#title' => $item->value,
+        '#url' => $url,
+        '#options' => $url->getOptions(),
+      ];
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Builds the \Drupal\Core\Url object for a field item.
+   *
+   * @param \Drupal\ethereum\Plugin\Field\FieldType\EthereumAddressItem $item
+   *   The  field item being rendered.
+   * @param array $network
+   *   An associative array with network information.
+   *
+   * @return \Drupal\Core\Url
+   *   A Url object.
+   */
+  protected function buildUrl(EthereumAddressItem $item, array $network) {
+    if (!empty($network['link_to_address'])) {
+      $network_link = str_replace('@address', $item->value, $network['link_to_address']);
+      $url = Url::fromUri($network_link);
+    }
+    else {
+      $url = Url::fromRoute('<none>');
+    }
+
+    $settings = $this->getSettings();
+    $options = $url->getOptions();
+
+    // Add optional 'rel' attribute to link options.
+    if (!empty($settings['rel'])) {
+      $options['attributes']['rel'] = $settings['rel'];
+    }
+    // Add optional 'target' attribute to link options.
+    if (!empty($settings['target'])) {
+      $options['attributes']['target'] = $settings['target'];
+    }
+    $url->setOptions($options);
+
+    return $url;
+  }
+
+}

--- a/src/Plugin/Field/FieldType/EthereumAddressFieldItemList.php
+++ b/src/Plugin/Field/FieldType/EthereumAddressFieldItemList.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\ethereum\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
+/**
+ * Represents a configurable ethereum_address field.
+ */
+class EthereumAddressFieldItemList extends FieldItemList {
+
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    // Nothing to do here.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function ensureComputedValue() {
+    /** @var \Drupal\ethereum\EthereumManagerInterface $ethereum_manager */
+    $ethereum_manager = \Drupal::service('ethereum.manager');
+
+    // Filter the items of the ethereum_address field to those that belong to
+    // the contextual Ethereum network ID.
+    if ($contextual_network_id = $ethereum_manager->getContextualNetworkId()) {
+      $this->filter(function ($item) use ($contextual_network_id) {
+        return $item->network === $contextual_network_id;
+      });
+    }
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/EthereumAddressWidget.php
+++ b/src/Plugin/Field/FieldWidget/EthereumAddressWidget.php
@@ -26,7 +26,37 @@ class EthereumAddressWidget extends StringTextfieldWidget {
     return [
       'size' => 42,
       'placeholder' => '0xaec98826319ef42aab9530a23306d5a9b113e23d',
+      'use_current_network' => TRUE,
     ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element = parent::settingsForm($form, $form_state);
+
+    $element['use_current_network'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Use current network'),
+      '#default_value' => $this->getSetting('use_current_network'),
+      '#description' => $this->t('The network selection will not be displayed and the current Ethereum network will be used as a default value.'),
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+
+    if ($this->getSetting('use_current_network')) {
+      $summary[] = $this->t('Use current network as default');
+    }
+
+    return $summary;
   }
 
   /**
@@ -35,14 +65,32 @@ class EthereumAddressWidget extends StringTextfieldWidget {
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
 
-    if ($element['value']['#default_value']) {
-      $element['value']['#attributes']['data-original-value'] = $element['value']['#default_value'];
-    }
-
     // Set a custom validation pattern.
     // @see https://www.w3schools.com/code/tryit.asp?filename=FEBTROZXKYL9
     $element['value']['#pattern'] = '0[x,X]{1}[0-9,a-f,A-F]{40}';
     $element['value']['#attributes']['title'] = $this->t('An Ethereum address must start with "0x", followed by 40 hexadecimal characters. For example: 0xaec98826319ef42aab9530a23306d5a9b113e23d');
+    $element['value']['#maxlength'] = $this->getSetting('size');
+
+    /** @var \Drupal\ethereum\EthereumManagerInterface $ethereum_manager */
+    $ethereum_manager = \Drupal::service('ethereum.manager');
+    $network_options = $ethereum_manager->getNetworksAsOptions();
+
+    if (!$this->getSetting('use_current_network')) {
+      $element['network'] = [
+        '#type' => 'select',
+        '#options' => $network_options,
+        '#default_value' => isset($items[$delta]->network) ? $items[$delta]->network : $ethereum_manager->getCurrentNetworkId(),
+        '#weight' => 10,
+      ];
+      $element['#type'] = 'container';
+      $element['#attributes']['class'][] = 'container-inline';
+    }
+    else {
+      $element['network'] = [
+        '#type' => 'value',
+        '#value' => $ethereum_manager->getCurrentNetworkId(),
+      ];
+    }
 
     return $element;
   }


### PR DESCRIPTION
Storing an Ethereum address by itself is not very useful, it can only be identified properly if it's combined with a network ID.

This PR depends on #32 because it uses the service added over there.