### PR TITLE
Improve the Ethereum server selection page.

### DIFF
--- a/ethereum.links.menu.yml
+++ b/ethereum.links.menu.yml
@@ -12,5 +12,5 @@ ethereum.admin_index:
 ethereum.settings:
   route_name: ethereum.settings
   parent: ethereum.admin_index
-  title: 'Ethereum Network Configuration'
-  description: 'Configure how Drupal connects to Ethereum.'
+  title: 'Ethereum network configuration'
+  description: 'Configure how Drupal connects to the Ethereum network.'

--- a/ethereum.routing.yml
+++ b/ethereum.routing.yml
@@ -45,3 +45,21 @@ entity.ethereum_server.delete_form:
     _title: 'Delete Ethereum Server Node'
   requirements:
     _permission: 'administer site configuration'
+
+entity.ethereum_server.enable:
+  path: '/admin/config/ethereum/network/server/{ethereum_server}/enable'
+  defaults:
+    _controller: '\Drupal\ethereum\Controller\EthereumUIController::ajaxOperation'
+    op: enable
+  requirements:
+    _permission: 'administer site configuration'
+    _csrf_token: 'TRUE'
+
+entity.ethereum_server.disable:
+  path: '/admin/config/ethereum/network/server/{ethereum_server}/disable'
+  defaults:
+    _controller: '\Drupal\ethereum\Controller\EthereumUIController::ajaxOperation'
+    op: disable
+  requirements:
+    _permission: 'administer site configuration'
+    _csrf_token: 'TRUE'

--- a/src/Controller/EthereumServerListBuilder.php
+++ b/src/Controller/EthereumServerListBuilder.php
@@ -14,8 +14,27 @@ class EthereumServerListBuilder extends ConfigEntityListBuilder {
   /**
    * {@inheritdoc}
    */
+  public function load() {
+    $entities = [
+      'enabled' => [],
+      'disabled' => [],
+    ];
+    /** @var \Drupal\ethereum\EthereumServerInterface $entity */
+    foreach (parent::load() as $entity) {
+      if ($entity->status()) {
+        $entities['enabled'][] = $entity;
+      }
+      else {
+        $entities['disabled'][] = $entity;
+      }
+    }
+    return $entities;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function buildHeader() {
-    $header['status'] = $this->t('Enabled');
     $header['id'] = $this->t('ID');
     $header['label'] = $this->t('Name');
     $header['network_id'] = $this->t('Network ID');
@@ -29,8 +48,6 @@ class EthereumServerListBuilder extends ConfigEntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     /** @var \Drupal\ethereum\EthereumServerInterface $entity */
-    $row['status'] = $entity->status() ? '✔' : '✘';
-
     $row['id'] = $entity->id();
 
     $row['label'] = new FormattableMarkup('
@@ -57,6 +74,58 @@ class EthereumServerListBuilder extends ConfigEntityListBuilder {
     $row['url'] = $entity->getUrl();
 
     return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $entities = $this->load();
+
+    $build['#type'] = 'container';
+    $build['#attributes']['id'] = 'ethereum-server-list';
+    $build['#attached']['library'][] = 'core/drupal.ajax';
+    $build['#cache'] = [
+      'contexts' => $this->entityType->getListCacheContexts(),
+      'tags' => $this->entityType->getListCacheTags(),
+    ];
+
+    $build['enabled']['heading']['#markup'] = '<h2>' . $this->t('Enabled', [], ['context' => 'Plural']) . '</h2>';
+    $build['disabled']['heading']['#markup'] = '<h2>' . $this->t('Disabled', [], ['context' => 'Plural']) . '</h2>';
+
+    foreach (['enabled', 'disabled'] as $status) {
+      $build[$status]['#type'] = 'container';
+      $build[$status]['table'] = [
+        '#type' => 'table',
+        '#header' => $this->buildHeader(),
+        '#rows' => [],
+      ];
+      foreach ($entities[$status] as $entity) {
+        $build[$status]['table']['#rows'][$entity->id()] = $this->buildRow($entity);
+      }
+    }
+    $build['enabled']['table']['#empty'] = $this->t('There are no enabled servers.');
+    $build['disabled']['table']['#empty'] = $this->t('There are no disabled servers.');
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultOperations(EntityInterface $entity) {
+    $operations = parent::getDefaultOperations($entity);
+
+    // Add AJAX functionality to enable/disable operations.
+    foreach (['enable', 'disable'] as $op) {
+      if (isset($operations[$op])) {
+        $operations[$op]['url'] = $entity->toUrl($op);
+        // Enable and disable operations should use AJAX.
+        $operations[$op]['attributes']['class'][] = 'use-ajax';
+      }
+    }
+
+    return $operations;
   }
 
 }

--- a/src/Controller/EthereumUIController.php
+++ b/src/Controller/EthereumUIController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\ethereum\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\ethereum\EthereumServerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+
+/**
+ * Returns responses for Ethereum UI routes.
+ */
+class EthereumUIController extends ControllerBase {
+
+  /**
+   * Calls a method on an ethereum_server entity and reloads the listing page.
+   *
+   * @param \Drupal\ethereum\EthereumServerInterface $ethereum_server
+   *   The server being acted upon.
+   * @param string $op
+   *   The operation to perform, e.g., 'enable' or 'disable'.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+   *   Either returns a rebuilt listing page as an AJAX response, or redirects
+   *   back to the listing page.
+   */
+  public function ajaxOperation(EthereumServerInterface $ethereum_server, $op, Request $request) {
+    // Perform the operation.
+    $ethereum_server->$op()->save();
+
+    // If the request is via AJAX, return the rendered list as JSON.
+    if ($request->request->get('js')) {
+      $list = $this->entityTypeManager()->getListBuilder('ethereum_server')->render();
+      $response = new AjaxResponse();
+      $response->addCommand(new ReplaceCommand('#ethereum-server-list', $list));
+      return $response;
+    }
+
+    // Otherwise, redirect back to the page.
+    return $this->redirect('entity.ethereum_server.collection');
+  }
+
+}

--- a/src/Entity/EthereumServer.php
+++ b/src/Entity/EthereumServer.php
@@ -39,6 +39,8 @@ use Ethereum\Ethereum;
  *   links = {
  *     "edit-form" = "/admin/config/ethereum/network/server/{ethereum_server}/edit",
  *     "delete-form" = "/admin/config/ethereum/network/server/{ethereum_server}/delete",
+ *     "enable" = "/admin/config/ethereum/network/server/{ethereum_server}/enable",
+ *     "disable" = "/admin/config/ethereum/network/server/{ethereum_server}/disable",
  *   }
  * )
  */

--- a/src/Form/EthereumSettingsForm.php
+++ b/src/Form/EthereumSettingsForm.php
@@ -55,7 +55,7 @@ class EthereumSettingsForm extends ConfigFormBase {
       '#type' => 'select',
       '#title' => $this->t('Backend server'),
       '#required' => TRUE,
-      '#description' => $this->t('Select a default Ethereum Node to connect Drupal backend to. Only enabled servers can be selected.'),
+      '#description' => $this->t('Select a default Ethereum Node to connect the Drupal backend to. Only enabled servers can be selected.'),
       '#options' => $enabled_servers,
       '#default_value' => $config->get('current_server'),
     ];
@@ -63,7 +63,7 @@ class EthereumSettingsForm extends ConfigFormBase {
     $form['default_network']['frontend_server'] = [
       '#type' => 'select',
       '#title' => $this->t('Frontend server'),
-      '#description' => $this->t('Select a default Ethereum Node to connect Drupal frontend to. Only enabled servers can be selected and it has to be on the same network as the backend server.'),
+      '#description' => $this->t('Select a default Ethereum Node to connect the Drupal frontend to. Only enabled servers can be selected and it has to be on the same network as the backend server.'),
       '#empty_option' => $this->t('Same as backend'),
       '#options' => $enabled_servers,
       '#default_value' => $config->get('frontend_server'),
@@ -71,7 +71,7 @@ class EthereumSettingsForm extends ConfigFormBase {
 
     $form['default_network']['infura_note'] = [
       '#type' => 'markup',
-      '#markup' => '<p><a href="https://infura.io/">Infura</a> is a webservice which provides access to Ethereum.<br />Infura requires a token for access. The "drupal" token only to get started. It is not intended for production use and may be revoked on extensive usage.<br /><b>Please <a href="https://infura.io/signup">register</a> your own free Infura token for your own application or run your own Ethereum node.</b><br /></p>',
+      '#markup' => '<p><a href="https://infura.io/">Infura</a> is a webservice which provides access to the Ethereum network.<br />Infura requires a token for access. The "drupal" token is only useful to get started quickly, it is not intended for production use and may be revoked on extensive usage.<br /><b>Please <a href="https://infura.io/signup">register</a> your own free Infura token for your application or run your own Ethereum node.</b><br /></p>',
     ];
 
     $form['#attached']['library'][] = 'ethereum/ethereum-admin-form';


### PR DESCRIPTION
I think we can improve the current way of enabling/disabling a server by following the pattern introduced by Views, and create two separate tables for Enabled/DIsabled servers.

We can also simplify the way a server is enabled or disabled by using AJAX operation for those two actions.

This is how it looks like with this patch:

![screenshot_2018-09-02 configure ethereum connection th local](https://user-images.githubusercontent.com/246655/44961209-d6570000-af15-11e8-8c4f-9e81168fcad9.png)
