### PR TITLE
Configuration edits: match standard casing + more

### DIFF
--- a/ethereum_smartcontract/ethereum_smartcontract.links.menu.yml
+++ b/ethereum_smartcontract/ethereum_smartcontract.links.menu.yml
@@ -1,5 +1,5 @@
 entity.smartcontract.collection:
   route_name: entity.smartcontract.collection
   parent: ethereum.admin_index
-  title: 'Ethereum Smart Contracts Configuration'
-  description: 'Manage Solidity smart contracts.'
+  title: 'Ethereum smart contracts interface'
+  description: 'Manage Solidity smart contracts deployed to an Ethereum blockchain.'


### PR DESCRIPTION
Drupal tends to capitalize the first letter and proper nouns in the configuration menu as well as leave out the word 'configuration' redundantly. I'm matching this "standard." While here I decided to strengthen the description attempting to simply explain its full use-case.